### PR TITLE
Allow top-level await.

### DIFF
--- a/src/nodes.coffee
+++ b/src/nodes.coffee
@@ -336,6 +336,12 @@ exports.Block = class Block extends Base
         prelude = @compileNode merge(o, indent: '')
         prelude.push @makeCode "\n"
       @expressions = rest
+    # Handle top-level await by wrapping in an async closure.
+    topAsync = !!@contains (node) -> node instanceof Op and node.isAwait()
+    if topAsync
+      generator = new Code([], Block.wrap @expressions)
+      callfunc = new Value(generator, [new Access new Literal 'call'])
+      @expressions = [new Call(callfunc, [new Literal 'this'])]
     fragments = @compileWithDeclarations o
     return fragments if o.bare
     [].concat prelude, @makeCode("(function() {\n"), fragments, @makeCode("\n}).call(this);\n")


### PR DESCRIPTION
Await can easily be supported at the top level; this change allows it.

This change is designed to make CoffeeScript a more effective platform
for learning to program.  Allowing top-level await allows beginners
to write simple programs that work with asynchronous input before
learning how to use functions.

(This solves a key problem with teaching in Javascript.)