### PR TITLE
Minor optimizations

### DIFF
--- a/lib/coffee-script/lexer.js
+++ b/lib/coffee-script/lexer.js
@@ -27,7 +27,7 @@
       this.seenFor = false;
       this.seenImport = false;
       this.seenExport = false;
-      this.exportList = false;
+      this.exportSpecifierList = false;
       this.chunkLine = opts.line || 0;
       this.chunkColumn = opts.column || 0;
       code = this.clean(code);
@@ -105,7 +105,7 @@
       }
       ref4 = this.tokens, prev = ref4[ref4.length - 1];
       tag = colon || (prev != null) && (((ref5 = prev[0]) === '.' || ref5 === '?.' || ref5 === '::' || ref5 === '?::') || !prev.spaced && prev[0] === '@') ? 'PROPERTY' : 'IDENTIFIER';
-      if (tag === 'IDENTIFIER' && (indexOf.call(JS_KEYWORDS, id) >= 0 || indexOf.call(COFFEE_KEYWORDS, id) >= 0) && !(this.exportList && indexOf.call(COFFEE_KEYWORDS, id) >= 0)) {
+      if (tag === 'IDENTIFIER' && (indexOf.call(JS_KEYWORDS, id) >= 0 || indexOf.call(COFFEE_KEYWORDS, id) >= 0) && !(this.exportSpecifierList && indexOf.call(COFFEE_KEYWORDS, id) >= 0)) {
         tag = id.toUpperCase();
         if (tag === 'WHEN' && (ref6 = this.tag(), indexOf.call(LINE_BREAK, ref6) >= 0)) {
           tag = 'LEADING_WHEN';
@@ -561,10 +561,9 @@
         }
       }
       if (value === '{' && (prev != null ? prev[0] : void 0) === 'EXPORT') {
-        this.exportList = true;
-      }
-      if (value === '}') {
-        this.exportList = false;
+        this.exportSpecifierList = true;
+      } else if (this.exportSpecifierList && value === '}') {
+        this.exportSpecifierList = false;
       }
       if (value === ';') {
         this.seenFor = this.seenImport = this.seenExport = false;

--- a/src/lexer.coffee
+++ b/src/lexer.coffee
@@ -45,7 +45,7 @@ exports.Lexer = class Lexer
     @seenFor    = no             # Used to recognize FORIN and FOROF tokens.
     @seenImport = no             # Used to recognize IMPORT FROM? AS? tokens.
     @seenExport = no             # Used to recognize EXPORT FROM? AS? tokens.
-    @exportList = no             # Used to identify when in an EXPORT {...} FROM? ...
+    @exportSpecifierList = no    # Used to identify when in an EXPORT {...} FROM? ...
 
     @chunkLine =
       opts.line or 0         # The start line for the current @chunk.
@@ -142,7 +142,7 @@ exports.Lexer = class Lexer
         'IDENTIFIER'
 
     if tag is 'IDENTIFIER' and (id in JS_KEYWORDS or id in COFFEE_KEYWORDS) and
-    not (@exportList and id in COFFEE_KEYWORDS)
+       not (@exportSpecifierList and id in COFFEE_KEYWORDS)
       tag = id.toUpperCase()
       if tag is 'WHEN' and @tag() in LINE_BREAK
         tag = 'LEADING_WHEN'
@@ -463,9 +463,9 @@ exports.Lexer = class Lexer
       return value.length if skipToken
 
     if value is '{' and prev?[0] is 'EXPORT'
-      @exportList = yes
-    if value is '}'
-      @exportList = no
+      @exportSpecifierList = yes
+    else if @exportSpecifierList and value is '}'
+      @exportSpecifierList = no
 
     if value is ';'
       @seenFor = @seenImport = @seenExport = no


### PR DESCRIPTION
Consistent naming; don’t reset the export list flag on every `}` encountered.

Other than this it looks good to me.